### PR TITLE
Fix tailwind css import error

### DIFF
--- a/FABLECRAFT NUXT BUILD/nuxt.config.ts
+++ b/FABLECRAFT NUXT BUILD/nuxt.config.ts
@@ -3,6 +3,18 @@ export default defineNuxtConfig({
   compatibilityDate: '2024-11-01',
   devtools: { enabled: true },
   
+  // Modules
+  modules: [
+    '@nuxtjs/tailwindcss',
+    '@nuxtjs/google-fonts',
+    '@nuxtjs/supabase',
+    '@pinia/nuxt',
+    '@vueuse/nuxt',
+    'shadcn-nuxt',
+    '@nuxt/image',
+    '@nuxtjs/web-vitals',
+  ],
+  
   // Development server configuration
   devServer: {
     port: 4269,


### PR DESCRIPTION
Add missing Nuxt modules to `nuxt.config.ts` to resolve Tailwind CSS import errors and enable other installed features.

---
<a href="https://cursor.com/background-agent?bcId=bc-020d014f-c763-49b7-90ee-82ed577fd529">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-020d014f-c763-49b7-90ee-82ed577fd529">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>